### PR TITLE
Fixes `config.assets.manifest` issue

### DIFF
--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -40,8 +40,10 @@ module Requirejs
 
         # NOTE: Using sprockets >= 3.x the rails_manifest_path is not a directory
         #       but a file. That's why we get the `dirname` if the given
-        #       `rails_manifest_path` is a file.
-        rails_manifest_path = File.dirname(rails_manifest_path) if File.file?(rails_manifest_path)
+        #       `rails_manifest_path` is a not a directory.
+        unless File.directory?(rails_manifest_path.to_s)
+          rails_manifest_path = File.dirname(rails_manifest_path)
+        end
 
         manifest_path = File.join(rails_manifest_path, 'rjs_manifest.yml')
         config.requirejs.manifest_path = Pathname.new(manifest_path)
@@ -61,7 +63,7 @@ module Requirejs
           config = app.config
 
           # NOTE: Not DRY -> extract
-          rails_manifest_path = config.assets.manifest ||= File.join(::Rails.public_path, config.assets.prefix)
+          rails_manifest_path = config.assets.manifest || File.join(::Rails.public_path, config.assets.prefix)
 
           rails_manifest = ::Sprockets::Manifest.new(app.assets, rails_manifest_path)
           if config.requirejs.manifest_path.exist? && rails_manifest


### PR DESCRIPTION
## Problem

Setting the Rails config `config.assets.manifest` using a recent
sprockets version (>= 3.0) makes the use of Requirejs::Rails impossible.

Sprockets change the content of the configuration from being a directory
to a file. Requirejs::Rails was still expecting a directory.
## Solution

Get the dirname of the given value if this value is a path to a file.
